### PR TITLE
Reset fluent interface scope

### DIFF
--- a/src/asfac.tests/src/com/thedevstop/asfac/FluentRegistrationTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/FluentRegistrationTests.as
@@ -1,6 +1,7 @@
 package com.thedevstop.asfac 
 {
 	import asunit.framework.TestCase;
+	import com.thedevstop.asfac.stubs.ConstructorWithRequiredParameters;
 	import com.thedevstop.asfac.stubs.HasObjectProperty;
 	import flash.errors.IllegalOperationError;
 	import flash.utils.Dictionary;
@@ -152,6 +153,38 @@ package com.thedevstop.asfac
 			var instance:Dictionary = AsFactoryLocator.factory.resolve(Dictionary);
 			
 			assertSame(instance, singletonDictionary);	
+		}
+		
+		public function test_unscoped_register_uses_default_scope_after_scoped_register():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var defaultItem:Object = { };
+			var scopedItem:Object = new Dictionary();
+			var scopeName:String = "nonDefaultScope";
+			
+			factory.inScope(scopeName).register(scopedItem).asType(Object);
+			factory.register(defaultItem).asType(Object);
+			var instance:Object = factory.resolve(Object);
+			
+			assertSame(defaultItem, instance);
+		}
+		
+		public function test_scoped_registrar_continues_registering_in_scope():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var object:Object = { };
+			var dictionary:Dictionary = new Dictionary();
+			var scopeName:String = "nonDefaultScope";
+			
+			var scopedRegistrar:IRegister = factory.inScope(scopeName);
+			scopedRegistrar.register(object).asType(Object);
+			scopedRegistrar.register(dictionary).asType(Dictionary);
+			
+			var objectInstance:Object = factory.fromScope(scopeName).resolve(Object);
+			var dictionaryInstance:Dictionary = factory.fromScope(scopeName).resolve(Dictionary);
+			
+			assertSame(objectInstance, object);
+			assertSame(dictionaryInstance, dictionary);
 		}
 	}
 }

--- a/src/asfac.tests/src/com/thedevstop/asfac/FluentResolutionTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/FluentResolutionTests.as
@@ -233,5 +233,38 @@ package com.thedevstop.asfac
 			
 			assertSame(instance, singletonDictionary);	
 		}
+		
+		public function test_unscoped_resolve_uses_default_scope_after_scoped_resolve():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var defaultItem:Object = { };
+			var scopedItem:Object = new Dictionary();
+			var scopeName:String = "nonDefaultScope";
+			
+			factory.inScope(scopeName).register(scopedItem).asType(Object);
+			factory.register(defaultItem).asType(Object);
+			var ignore:Object = factory.fromScope(scopeName).resolve(Object);
+			var instance:Object = factory.resolve(Object);
+			
+			assertSame(defaultItem, instance);
+		}
+		
+		public function test_scoped_resolver_continues_resolving_from_scope():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var object:Object = { };
+			var dictionary:Dictionary = new Dictionary();
+			var scopeName:String = "nonDefaultScope";
+			
+			factory.inScope(scopeName).register(object).asType(Object);
+			factory.inScope(scopeName).register(dictionary).asType(Dictionary);
+			
+			var scopedResolver:IResolve = factory.fromScope(scopeName);
+			var objectInstance:Object = scopedResolver.resolve(Object);
+			var dictionaryInstance:Dictionary = scopedResolver.resolve(Dictionary);
+			
+			assertSame(objectInstance, object);
+			assertSame(dictionaryInstance, dictionary);
+		}
 	}
 }

--- a/src/asfac/src/com/thedevstop/asfac/FluentAsFactory.as
+++ b/src/asfac/src/com/thedevstop/asfac/FluentAsFactory.as
@@ -27,6 +27,7 @@ package com.thedevstop.asfac
 		 */
 		public function register(instance:*):IRegisterAsType
 		{
+			_registrar.inScope(AsFactory.DefaultScopeName);
 			return _registrar.register(instance);
 		}
 		
@@ -57,6 +58,7 @@ package com.thedevstop.asfac
 		 */
 		public function resolve(type:Class):*
 		{
+			_resolver.fromScope(AsFactory.DefaultScopeName);
 			return _resolver.resolve(type);
 		}
 	}


### PR DESCRIPTION
Set registrar and resolver back to default scope when not performing scoped action.
