### PR TITLE
Scope shouldn't change in scoped registrar/resolvers

### DIFF
--- a/src/asfac.tests/src/com/thedevstop/asfac/FluentRegistrationTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/FluentRegistrationTests.as
@@ -1,4 +1,4 @@
-﻿package com.thedevstop.asfac 
+package com.thedevstop.asfac 
 {
 	import asunit.framework.TestCase;
 	import com.thedevstop.asfac.stubs.ConstructorWithRequiredParameters;
@@ -190,7 +190,7 @@
 			assertSame(defaultItem, instance);
 		}
 		
-		public function test_scoped_registrar_continues_registering_in_scope():void
+		public function test_scoped_registrar_registers_in_scope():void
 		{
 			var factory:FluentAsFactory = new FluentAsFactory();
 			var object:Object = { };
@@ -199,6 +199,26 @@
 			
 			var scopedRegistrar:IRegister = factory.inScope(scopeName);
 			scopedRegistrar.register(object).asType(Object);
+			scopedRegistrar.register(dictionary).asType(Dictionary);
+			
+			var objectInstance:Object = factory.fromScope(scopeName).resolve(Object);
+			var dictionaryInstance:Dictionary = factory.fromScope(scopeName).resolve(Dictionary);
+			
+			assertSame(objectInstance, object);
+			assertSame(dictionaryInstance, dictionary);
+		}
+		
+		public function test_scoped_registrar_continues_registering_in_scope():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var object:Object = { };
+			var dictionary:Dictionary = new Dictionary();
+			var scopeName:String = "nonDefaultScope";
+			var anotherScopeName:String = "anotherNonDefaultScope";
+			
+			var scopedRegistrar:IRegister = factory.inScope(scopeName);
+			scopedRegistrar.register(object).asType(Object);
+			var anotherScopedRegistrar:IRegister = factory.inScope(anotherScopeName);
 			scopedRegistrar.register(dictionary).asType(Dictionary);
 			
 			var objectInstance:Object = factory.fromScope(scopeName).resolve(Object);

--- a/src/asfac.tests/src/com/thedevstop/asfac/FluentResolutionTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/FluentResolutionTests.as
@@ -330,7 +330,7 @@ package com.thedevstop.asfac
 			assertSame(defaultItem, instance);
 		}
 		
-		public function test_scoped_resolver_continues_resolving_from_scope():void
+		public function test_scoped_resolver_resolves_from_scope():void
 		{
 			var factory:FluentAsFactory = new FluentAsFactory();
 			var object:Object = { };
@@ -342,6 +342,26 @@ package com.thedevstop.asfac
 			
 			var scopedResolver:IResolve = factory.fromScope(scopeName);
 			var objectInstance:Object = scopedResolver.resolve(Object);
+			var dictionaryInstance:Dictionary = scopedResolver.resolve(Dictionary);
+			
+			assertSame(objectInstance, object);
+			assertSame(dictionaryInstance, dictionary);
+		}
+		
+		public function test_scoped_resolver_continues_resolving_from_scope():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var object:Object = { };
+			var dictionary:Dictionary = new Dictionary();
+			var scopeName:String = "nonDefaultScope";
+			var anotherScopeName:String = "anotherNonDefaultScope";
+			
+			factory.inScope(scopeName).register(object).asType(Object);
+			factory.inScope(scopeName).register(dictionary).asType(Dictionary);
+			
+			var scopedResolver:IResolve = factory.fromScope(scopeName);
+			var objectInstance:Object = scopedResolver.resolve(Object);
+			var anotherScopedResolver:IResolve = factory.fromScope(anotherScopeName);
 			var dictionaryInstance:Dictionary = scopedResolver.resolve(Dictionary);
 			
 			assertSame(objectInstance, object);

--- a/src/asfac/src/com/thedevstop/asfac/FluentAsFactory.as
+++ b/src/asfac/src/com/thedevstop/asfac/FluentAsFactory.as
@@ -7,8 +7,8 @@ package com.thedevstop.asfac
 	public class FluentAsFactory implements IRegisterInScope, IResolveFromScope
 	{	
 		private var _factory:AsFactory;
-		private var _registrar:FluentRegistrar;
-		private var _resolver:FluentResolver;
+		private var _defaultRegistrar:FluentRegistrar;
+		private var _defaultResolver:FluentResolver;
 		
 		/**
 		 * Constructs a new FluentAsFactory.
@@ -17,8 +17,8 @@ package com.thedevstop.asfac
 		public function FluentAsFactory(factory:AsFactory = null)
 		{
 			_factory = factory || new AsFactory();
-			_registrar = new FluentRegistrar(_factory);
-			_resolver = new FluentResolver(_factory);
+			_defaultRegistrar = new FluentRegistrar(_factory);
+			_defaultResolver = new FluentResolver(_factory);
 		}
 		
 		/**
@@ -28,8 +28,7 @@ package com.thedevstop.asfac
 		 */
 		public function register(instance:*):IRegisterAsType
 		{
-			_registrar.inScope(AsFactory.DefaultScopeName);
-			return _registrar.register(instance);
+			return _defaultRegistrar.register(instance);
 		}
 		
 		/**
@@ -40,9 +39,9 @@ package com.thedevstop.asfac
 		public function inScope(scope:*):IRegister
 		{
 			if (scope is Class)
-				return _registrar.inScope(getQualifiedClassName(scope));
+				scope = getQualifiedClassName(scope);
 				
-			return _registrar.inScope(scope);
+			return new FluentRegistrar(_factory).inScope(scope);
 		}
 		
 		/**
@@ -53,9 +52,9 @@ package com.thedevstop.asfac
 		public function fromScope(scope:*):IResolve
 		{
 			if (scope is Class)
-				return _resolver.fromScope(getQualifiedClassName(scope));
+				scope = getQualifiedClassName(scope);
 			
-			return _resolver.fromScope(scope);
+			return new FluentResolver(_factory).fromScope(scope);
 		}
 		
 		/**
@@ -65,8 +64,7 @@ package com.thedevstop.asfac
 		 */
 		public function resolve(type:Class):*
 		{
-			_resolver.fromScope(AsFactory.DefaultScopeName);
-			return _resolver.resolve(type);
+			return _defaultResolver.resolve(type);
 		}
 	}
 }


### PR DESCRIPTION
Each call to inScope/fromScope receives a new instance of a FluentRegistrar/FluentResolver.
