### PR TITLE
Support multiple registration for a single type

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ factory.register(InMemoryUserRepository).asType(IUserRepository);
 var userRepository:IUserRepository = factory.resolve(IUserRepository);
 ```
 
+Register type as a singleton
+
+``` actionscript
+// Fluent
+factory.register(ApplicationModel).asSingleton();
+```
+
 Register type for instance (singleton instance on each request)
     
 ``` actionscript
@@ -113,6 +120,20 @@ factory.inScope(User).register(InMemoryUserRepository).asType(IRepository);
 var repository:IRepository = factory.fromScope(User).resolve(IRepository);
 ```
 
+Multi-register types for an interface
+
+``` actionscript
+// Standard
+factory.register(NaiveStrategy, IStrategy, NaiveStrategy, false);
+factory.register(ExpertStrategy, IStrategy, ExpertStrategy, false);
+var strategies:Array = factory.resolveAll(IStrategy);
+
+// Fluent
+factory.register(NaiveStrategy).forType(IStrategy);
+factory.register(ExpertStrategy).forType(IStrategy);
+var strategies:Array = factory.resolveAll(IStrategy);
+```
+
 Register an instance for interface
 
 ``` actionscript
@@ -144,7 +165,7 @@ factory.register(buildMyRepository).asType(IUserRepository);
 var userRepository:IUserRepository = factory.resolve(IUserRepository);
 ```
 
-Resovle type with property injection
+Resolve type with property injection
 
 ``` actionscript
 public class ApplicationContext

--- a/src/asfac.tests/asfac.tests.as3proj
+++ b/src/asfac.tests/asfac.tests.as3proj
@@ -8,10 +8,11 @@
     <movie fps="30" />
     <movie width="800" />
     <movie height="600" />
-    <movie version="10" />
+    <movie version="11" />
     <movie minorVersion="1" />
     <movie platform="Flash Player" />
     <movie background="#FFFFFF" />
+    <movie preferredSDK="Flex 4.6.0, AIR 3.1;4.6.0, 3.1;" />
   </output>
   <!-- Other classes to be compiled into your SWF -->
   <classpaths>
@@ -22,9 +23,11 @@
   <!-- Build options -->
   <build>
     <option accessible="False" />
+    <option advancedTelemetry="False" />
     <option allowSourcePathOverlap="False" />
     <option benchmark="False" />
     <option es="False" />
+    <option inline="False" />
     <option locale="" />
     <option loadConfig="" />
     <option optimize="True" />
@@ -64,7 +67,7 @@
   </rslPaths>
   <!-- Intrinsic Libraries -->
   <intrinsics>
-    <!-- example: <element path="..." /> -->
+    <element path="Library\AS3\frameworks\Flex3" />
   </intrinsics>
   <!-- Assets to embed into the output SWF -->
   <library>
@@ -76,7 +79,7 @@
   </compileTargets>
   <!-- Paths to exclude from the Project Explorer tree -->
   <hiddenPaths>
-    <!-- example: <hidden path="..." /> -->
+    <hidden path="obj" />
   </hiddenPaths>
   <!-- Executed before build -->
   <preBuildCommand />
@@ -86,6 +89,7 @@
   <options>
     <option showHiddenPaths="False" />
     <option testMovie="Default" />
+    <option testMovieCommand="" />
   </options>
   <!-- Plugin storage -->
   <storage />

--- a/src/asfac.tests/src/com/thedevstop/asfac/FluentRegistrationTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/FluentRegistrationTests.as
@@ -82,6 +82,17 @@ package com.thedevstop.asfac
 			assertSame(result1, result2);
 		}
 		
+		public function test_should_allow_register_type_as_singleton2():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			
+			factory.register(Dictionary).asSingleton();
+			
+			var result1:Object = factory.resolve(Dictionary);
+			var result2:Object = factory.resolve(Dictionary);
+			assertSame(result1, result2);
+		}
+		
 		public function test_should_retun_new_instances_when_not_registered_as_singleton():void
 		{
 			var factory:FluentAsFactory = new FluentAsFactory();

--- a/src/asfac.tests/src/com/thedevstop/asfac/FluentResolutionTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/FluentResolutionTests.as
@@ -8,6 +8,7 @@ package com.thedevstop.asfac
 	import flash.display.AVM1Movie;
 	import flash.errors.IllegalOperationError;
 	import flash.utils.Dictionary;
+	import mx.collections.ArrayCollection;
 	
 	/**
 	 * ...
@@ -255,7 +256,22 @@ package com.thedevstop.asfac
 
 			assertTrue(result.constructor == Dictionary);
 		}
-
+		
+		public function test_resolveAll_should_resolve_from_all_scopes():void
+		{
+			var factory:FluentAsFactory = new FluentAsFactory();
+			var obj1:Object = { };
+			var obj2:Object = { };
+			
+			factory.inScope("obj1").register(obj1).asType(Object);
+			factory.inScope("obj2").register(obj2).asType(Object);
+			
+			var results:ArrayCollection = new ArrayCollection(factory.resolveAll(Object));
+			
+			assertTrue(results.contains(obj1));
+			assertTrue(results.contains(obj2));
+		}
+		
 		public function test_scoped_resolve_resolves_constructor_dependencies_from_scope():void
 		{
 			var factory:FluentAsFactory = new FluentAsFactory();

--- a/src/asfac.tests/src/com/thedevstop/asfac/ResolutionTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/ResolutionTests.as
@@ -6,6 +6,7 @@ package com.thedevstop.asfac
 	import com.thedevstop.asfac.stubs.IPoint;
 	import flash.errors.IllegalOperationError;
 	import flash.utils.Dictionary;
+	import mx.collections.ArrayCollection;
 	
 	/**
 	 * ...
@@ -241,6 +242,21 @@ package com.thedevstop.asfac
 			var result:Object = factory.resolve(Dictionary, obj);
 
 			assertTrue(result.constructor == Dictionary);
+		}
+		
+		public function test_resolveAll_should_resolve_from_all_scopes():void
+		{
+			var factory:AsFactory = new AsFactory();
+			var obj1:Object = { };
+			var obj2:Object = { };
+			
+			factory.register(obj1, Object, "obj1");
+			factory.register(obj2, Object, "obj2");
+			
+			var results:ArrayCollection = new ArrayCollection(factory.resolveAll(Object));
+			
+			assertTrue(results.contains(obj1));
+			assertTrue(results.contains(obj2));
 		}
 
 		public function test_should_resolve_from_class_scope():void

--- a/src/asfac/src/com/thedevstop/asfac/AsFactory.as
+++ b/src/asfac/src/com/thedevstop/asfac/AsFactory.as
@@ -159,8 +159,8 @@ package com.thedevstop.asfac
 			var registrationsByScope:Dictionary = _registrations[type];
 			if (registrationsByScope)
 			{
-				for (var scopeName:String in _registrations)
-					instances.push(_registrations[scopeName](this, scopeName));
+				for (var scopeName:String in registrationsByScope)
+					instances.push(registrationsByScope[scopeName](this, scopeName));
 			}
 			
 			return instances;

--- a/src/asfac/src/com/thedevstop/asfac/AsFactory.as
+++ b/src/asfac/src/com/thedevstop/asfac/AsFactory.as
@@ -279,8 +279,8 @@ package com.thedevstop.asfac
 			{
 				if (hasInjectMetadata(variable))
 				{
-					var propertyType:Class = Class(getDefinitionByName(variable.@type.toString()));
-					typeDescription.injectableProperties.push( { name:variable.@name.toString(), type:propertyType } ); 
+					var variableType:Class = Class(getDefinitionByName(variable.@type.toString()));
+					typeDescription.injectableProperties.push( { name:variable.@name.toString(), type:variableType } ); 
 				}
 			}
 			

--- a/src/asfac/src/com/thedevstop/asfac/AsFactory.as
+++ b/src/asfac/src/com/thedevstop/asfac/AsFactory.as
@@ -148,6 +148,25 @@ package com.thedevstop.asfac
 		}
 		
 		/**
+		 * Return all instances of a registered type from all scopes.
+		 * @param	type The type being requested.
+		 * @return An Array of all the resolved instances.
+		 */
+		public function resolveAll(type:Class):Array
+		{
+			var instances:Array = [];
+			
+			var registrationsByScope:Dictionary = _registrations[type];
+			if (registrationsByScope)
+			{
+				for (var scopeName:String in _registrations)
+					instances.push(_registrations[scopeName](this, scopeName));
+			}
+			
+			return instances;
+		}
+		
+		/**
 		 * Resolves the desired type using prior registrations.
 		 * @param	type The type being requested.
 		 * @param	scopeName The name of the scope being resolved from.
@@ -256,6 +275,15 @@ package com.thedevstop.asfac
 				}
 			}
 			
+			for each (var variable:XML in description.factory.variable)
+			{
+				if (hasInjectMetadata(variable))
+				{
+					var propertyType:Class = Class(getDefinitionByName(variable.@type.toString()));
+					typeDescription.injectableProperties.push( { name:variable.@name.toString(), type:propertyType } ); 
+				}
+			}
+			
 			return typeDescription;
 		}
 		
@@ -265,15 +293,22 @@ package com.thedevstop.asfac
 		 * @return True if the Inject metadata is present, otherwise false.
 		 */
 		private function shouldInjectAccessor(accessor:XML):Boolean
+		{			
+			return (accessor.@access == "readwrite" || accessor.@access == "writeonly") 
+				&& hasInjectMetadata(accessor);
+		}
+		
+		/**
+		 * Determines whether the member should be injected.
+		 * @param	member A variable or accessor node from a class description xml.
+		 * @return True if the Inject metadata is present, otherwise false.
+		 */
+		private function hasInjectMetadata(member:XML):Boolean
 		{				
-			if (accessor.@access == "readwrite" ||
-				accessor.@access == "write")
+			for each (var metadata:XML in member.metadata)
 			{
-				for each (var metadata:XML in accessor.metadata)
-				{
-					if (metadata.@name.toString() == "Inject")
-						return true;
-				}
+				if (metadata.@name.toString() == "Inject")
+					return true;
 			}
 			
 			return false;

--- a/src/asfac/src/com/thedevstop/asfac/FluentAsFactory.as
+++ b/src/asfac/src/com/thedevstop/asfac/FluentAsFactory.as
@@ -1,6 +1,5 @@
 package com.thedevstop.asfac 
 {
-	import avmplus.getQualifiedClassName;
 	/**
 	 * AsFactory wrapped in a fluent interface.
 	 */
@@ -19,6 +18,7 @@ package com.thedevstop.asfac
 			_factory = factory || new AsFactory();
 			_defaultRegistrar = new FluentRegistrar(_factory);
 			_defaultResolver = new FluentResolver(_factory);
+			register(this).asType(FluentAsFactory);
 		}
 		
 		/**
@@ -38,9 +38,6 @@ package com.thedevstop.asfac
 		 */
 		public function inScope(scope:*):IRegister
 		{
-			if (scope is Class)
-				scope = getQualifiedClassName(scope);
-				
 			return new FluentRegistrar(_factory).inScope(scope);
 		}
 		
@@ -51,9 +48,6 @@ package com.thedevstop.asfac
 		 */
 		public function fromScope(scope:*):IResolve
 		{
-			if (scope is Class)
-				scope = getQualifiedClassName(scope);
-			
 			return new FluentResolver(_factory).fromScope(scope);
 		}
 		
@@ -65,6 +59,16 @@ package com.thedevstop.asfac
 		public function resolve(type:Class):*
 		{
 			return _defaultResolver.resolve(type);
+		}
+		
+		/**
+		 * Return all instances of a registered type from all scopes.
+		 * @param	type The type being requested.
+		 * @return An Array of all the resolved instances.
+		 */
+		public function resolveAll(type:Class):Array 
+		{
+			return _factory.resolveAll(type);
 		}
 	}
 }

--- a/src/asfac/src/com/thedevstop/asfac/FluentRegistrar.as
+++ b/src/asfac/src/com/thedevstop/asfac/FluentRegistrar.as
@@ -36,6 +36,9 @@ package com.thedevstop.asfac
 		 */
 		public function inScope(scope:*):IRegister
 		{
+			if (scope is Class)
+				scope = getQualifiedClassName(scope);
+			
 			_scope = scope;
 			
 			return this;
@@ -56,10 +59,21 @@ package com.thedevstop.asfac
 		}
 		
 		/**
+		 * Continues the multi-registration by specifying the type of dependency.
+		 * @param	type The type of dependency this registration resolves.
+		 * @return The ability to specify the resolution is a singleton.
+		 */
+		public function forType(type:Class):IRegisterAsSingleton
+		{
+			return new FluentRegistrar(_factory).inScope(_instance).register(_instance).asType(type);
+		}
+		
+		/**
 		 * Finishes this registration by specifying that the instance should be treated as a singleton.
 		 */
 		public function asSingleton():void
 		{
+			_type = _type || _instance;
 			_asSingleton = true;
 			
 			updateRegistration();

--- a/src/asfac/src/com/thedevstop/asfac/FluentRegistrar.as
+++ b/src/asfac/src/com/thedevstop/asfac/FluentRegistrar.as
@@ -25,6 +25,8 @@ package com.thedevstop.asfac
 		public function register(instance:*):IRegisterAsType
 		{
 			_instance = instance;
+			_type = null;
+			_asSingleton = false;
 			
 			return this;
 		}

--- a/src/asfac/src/com/thedevstop/asfac/FluentResolver.as
+++ b/src/asfac/src/com/thedevstop/asfac/FluentResolver.as
@@ -41,9 +41,22 @@ package com.thedevstop.asfac
 		 */
 		public function fromScope(scope:*):IResolve
 		{
+			if (scope is Class)
+				scope = getQualifiedClassName(scope);
+			
 			_scope = scope;
 			
 			return this;
+		}
+		
+		/**
+		 * Return all instances of a registered type from all scopes.
+		 * @param	type The type being requested.
+		 * @return An Array of all the resolved instances.
+		 */
+		public function resolveAll(type:Class):Array 
+		{
+			return _factory.resolveAll(type);
 		}
 	}
 }

--- a/src/asfac/src/com/thedevstop/asfac/IRegisterAsType.as
+++ b/src/asfac/src/com/thedevstop/asfac/IRegisterAsType.as
@@ -1,5 +1,5 @@
 package com.thedevstop.asfac 
-{	
+{
 	/**
 	 * Allows the specification of the Type being registered.
 	 */
@@ -11,5 +11,17 @@ package com.thedevstop.asfac
 		 * @return The ability to specify the resolution is a singleton.
 		 */
 		function asType(type:Class):IRegisterAsSingleton
+		
+		/**
+		 * Continues the multi-registration by specifying the type of dependency.
+		 * @param	type The type of dependency this registration resolves.
+		 * @return The ability to specify the resolution is a singleton.
+		 */
+		function forType(type:Class):IRegisterAsSingleton
+		
+		/**
+		 * Finishes this registration by specifying that the instance should be treated as a singleton.
+		 */
+		function asSingleton():void
 	}
 }

--- a/src/asfac/src/com/thedevstop/asfac/IResolveFromScope.as
+++ b/src/asfac/src/com/thedevstop/asfac/IResolveFromScope.as
@@ -18,5 +18,12 @@ package com.thedevstop.asfac
 		 * @return	The ability to resolve from this scope.
 		 */
 		function resolve(type:Class):*
+		
+		/**
+		 * Return all instances of a registered type from all scopes.
+		 * @param	type The type being requested.
+		 * @return An Array of all the resolved instances.
+		 */
+		function resolveAll(type:Class):Array
 	}	
 }


### PR DESCRIPTION
**Problem:**

I have multiple types of `ITask` that I would like to register with the factory and retrieve all at once later when displaying them to the user.

**Suggestion:**

Multi-register types for an interface
 
 ``` actionscript
 // Standard
 factory.register(NaiveStrategy, IStrategy, NaiveStrategy, false);
 factory.register(ExpertStrategy, IStrategy, ExpertStrategy, false);
 var strategies:Array = factory.resolveAll(IStrategy);
 
 // Fluent
 factory.register(NaiveStrategy).forType(IStrategy);
 factory.register(ExpertStrategy).forType(IStrategy);
 var strategies:Array = factory.resolveAll(IStrategy);
 ```

Since we make multiple registrations for a type by changing scope, provide a method for resolving a type from all scopes. Make it easy to create these registrations in the Fluent interface by adding a `forType` to complement `asType`. `forType` will set the scope name based on the registered instance.