### PR TITLE
resolveAll(T) when resolving Vector.<T>

### DIFF
--- a/src/asfac.tests/src/com/thedevstop/asfac/ResolutionTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/ResolutionTests.as
@@ -4,6 +4,7 @@ package com.thedevstop.asfac
 	import com.thedevstop.asfac.stubs.ConstructorWithRequiredParameters;
 	import com.thedevstop.asfac.stubs.HasObjectProperty;
 	import com.thedevstop.asfac.stubs.IPoint;
+	import com.thedevstop.asfac.stubs.InjectDictionaryVector;
 	import flash.errors.IllegalOperationError;
 	import flash.utils.Dictionary;
 	import mx.collections.ArrayCollection;
@@ -357,6 +358,24 @@ package com.thedevstop.asfac
 			var instance:Dictionary = factory.resolve(Dictionary, scopeName, true);
 			
 			assertSame(instance, defaultDictionary);			
+		}
+		
+		public function test_injected_vector_resolve_should_resolve_all():void
+		{
+			var factory:AsFactory = new AsFactory();
+			var scopeName:String = "nonDefaultScope";
+			var defaultDictionary:Dictionary = new Dictionary();
+			var scopedDictionary:Dictionary = new Dictionary();
+			
+			factory.register(defaultDictionary, Dictionary, AsFactory.DefaultScopeName);
+			factory.register(scopedDictionary, Dictionary, scopeName);
+			
+			var instance:InjectDictionaryVector = factory.resolve(InjectDictionaryVector);
+			
+			assertTrue(instance.dictionaries.length == 2);
+			assertTrue(instance.dictionaries[0] == defaultDictionary || instance.dictionaries[0] == scopedDictionary);
+			assertTrue(instance.dictionaries[1] == defaultDictionary || instance.dictionaries[1] == scopedDictionary);
+			assertTrue(instance.dictionaries[0] != instance.dictionaries[1]);
 		}
 	}
 }

--- a/src/asfac.tests/src/com/thedevstop/asfac/ResolutionTests.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/ResolutionTests.as
@@ -1,6 +1,7 @@
 package com.thedevstop.asfac 
 {
 	import asunit.framework.TestCase;
+	import com.thedevstop.asfac.stubs.ConstructDictionaryVector;
 	import com.thedevstop.asfac.stubs.ConstructorWithRequiredParameters;
 	import com.thedevstop.asfac.stubs.HasObjectProperty;
 	import com.thedevstop.asfac.stubs.IPoint;
@@ -371,6 +372,24 @@ package com.thedevstop.asfac
 			factory.register(scopedDictionary, Dictionary, scopeName);
 			
 			var instance:InjectDictionaryVector = factory.resolve(InjectDictionaryVector);
+			
+			assertTrue(instance.dictionaries.length == 2);
+			assertTrue(instance.dictionaries[0] == defaultDictionary || instance.dictionaries[0] == scopedDictionary);
+			assertTrue(instance.dictionaries[1] == defaultDictionary || instance.dictionaries[1] == scopedDictionary);
+			assertTrue(instance.dictionaries[0] != instance.dictionaries[1]);
+		}
+		
+		public function test_contruct_vector_resolve_should_resolve_all():void
+		{
+			var factory:AsFactory = new AsFactory();
+			var scopeName:String = "nonDefaultScope";
+			var defaultDictionary:Dictionary = new Dictionary();
+			var scopedDictionary:Dictionary = new Dictionary();
+			
+			factory.register(defaultDictionary, Dictionary, AsFactory.DefaultScopeName);
+			factory.register(scopedDictionary, Dictionary, scopeName);
+			
+			var instance:ConstructDictionaryVector = factory.resolve(ConstructDictionaryVector);
 			
 			assertTrue(instance.dictionaries.length == 2);
 			assertTrue(instance.dictionaries[0] == defaultDictionary || instance.dictionaries[0] == scopedDictionary);

--- a/src/asfac.tests/src/com/thedevstop/asfac/stubs/ConstructDictionaryVector.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/stubs/ConstructDictionaryVector.as
@@ -1,0 +1,14 @@
+package com.thedevstop.asfac.stubs 
+{
+	import flash.utils.Dictionary;
+
+	public class ConstructDictionaryVector 
+	{
+		public var dictionaries:Vector.<Dictionary>;
+		
+		public function ConstructDictionaryVector(dictionaries:Vector.<Dictionary>)
+		{
+			this.dictionaries = dictionaries;
+		}
+	}
+}

--- a/src/asfac.tests/src/com/thedevstop/asfac/stubs/InjectDictionaryVector.as
+++ b/src/asfac.tests/src/com/thedevstop/asfac/stubs/InjectDictionaryVector.as
@@ -1,0 +1,16 @@
+package com.thedevstop.asfac.stubs 
+{
+	import flash.utils.Dictionary;
+
+	public class InjectDictionaryVector 
+	{
+		[Inject]
+		public var dictionaries:Vector.<Dictionary>;
+		
+		
+		public function InjectDictionaryVector() 
+		{
+			
+		}
+	}
+}


### PR DESCRIPTION
Injecting a property of type Vector.<T> should populate it will the results of resolveAll(T).
